### PR TITLE
Move dataset metadata retrieval to DataFetcher

### DIFF
--- a/app/src/features/dataset_explorer/DataTable.tsx
+++ b/app/src/features/dataset_explorer/DataTable.tsx
@@ -27,8 +27,8 @@ function TableHeader({ column }: { column: HeaderGroup<any> }) {
 function TableHeaderGroup({ group }: { group: HeaderGroup<any> }) {
   return (
     <TableRow {...group.getHeaderGroupProps()}>
-      {group.headers.map((col) => (
-        <TableHeader column={col} />
+      {group.headers.map((col, index) => (
+        <TableHeader column={col} key={index} />
       ))}
     </TableRow>
   );
@@ -66,8 +66,8 @@ function DataTable(props: { columns: any[]; data: any[] }) {
     prepareRow(row);
     return (
       <TableRow {...row.getRowProps()}>
-        {row.cells.map((cell) => (
-          <CustomTableCell cell={cell} />
+        {row.cells.map((cell, index) => (
+          <CustomTableCell cell={cell} key={index} />
         ))}
       </TableRow>
     );
@@ -77,13 +77,13 @@ function DataTable(props: { columns: any[]; data: any[] }) {
     <Paper className={styles.DataTable}>
       <MaUTable {...getTableProps()}>
         <TableHead>
-          {headerGroups.map((group) => (
-            <TableHeaderGroup group={group} />
+          {headerGroups.map((group, index) => (
+            <TableHeaderGroup group={group} key={index} />
           ))}
         </TableHead>
         <TableBody {...getTableBodyProps()}>
-          {page.map((row: Row<any>) => (
-            <CustomTableRow row={row} />
+          {page.map((row: Row<any>, index) => (
+            <CustomTableRow row={row} key={index} />
           ))}
         </TableBody>
         <TableFooter>

--- a/app/src/features/dataset_explorer/DatasetExplorer.test.tsx
+++ b/app/src/features/dataset_explorer/DatasetExplorer.test.tsx
@@ -79,9 +79,7 @@ describe("DatasetExplorer", () => {
     );
     mockLoadDataset.mockReturnValue(Promise.resolve(STATE_NAMES_DATASET_DATA));
 
-    const { findByTestId, findByText, queryByText } = render(
-      <DatasetExplorer />
-    );
+    const { findByTestId } = render(<DatasetExplorer />);
     fireEvent.click(
       await findByTestId("preview-" + STATE_NAMES_DATASET_METADATA.id)
     );

--- a/app/src/features/dataset_explorer/DatasetExplorer.test.tsx
+++ b/app/src/features/dataset_explorer/DatasetExplorer.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import DatasetExplorer from "./DatasetExplorer";
+import DataFetcher from "../../utils/DataFetcher";
+import { DatasetMetadata } from "../../utils/DatasetMetadata";
+
+const STATE_NAMES_DATASET_METADATA: DatasetMetadata = {
+  id: "state_names",
+  name: "State Names",
+  description: "List of states and their FIPS codes.",
+  fields: [
+    { data_type: "string", description: "FIELD_NAME1", data_source_id: "DS1" },
+    { data_type: "string", description: "FIELD_NAME2", data_source_id: "DS1" },
+  ],
+};
+
+const STATE_NAMES_DATASET_DATA = {
+  columns: [
+    { Header: "FIELD_NAME1", " accessor": "FIELD_NAME1" },
+    { Header: "FIELD_NAME2", " accessor": "FIELD_NAME2" },
+  ],
+  data: [{ FIELD_NAME1: "Alabama", FIELD_NAME2: "01" }],
+};
+
+describe("DatasetExplorer", () => {
+  const mockGetDatasets = jest.fn();
+  const mockLoadDataset = jest.fn();
+
+  beforeEach(() => {
+    jest.mock("../../utils/DataFetcher");
+    DataFetcher.prototype.getDatasets = mockGetDatasets;
+    DataFetcher.prototype.loadDataset = mockLoadDataset;
+  });
+
+  afterEach(() => {
+    mockGetDatasets.mockClear();
+    mockLoadDataset.mockClear();
+  });
+
+  test("renders dataset metadata retrieved from DataFetcher", async () => {
+    mockGetDatasets.mockReturnValue(
+      Promise.resolve([STATE_NAMES_DATASET_METADATA])
+    );
+
+    const { findByText } = render(<DatasetExplorer />);
+
+    expect(mockGetDatasets).toHaveBeenCalledTimes(1);
+    expect(mockLoadDataset).toHaveBeenCalledTimes(0);
+    expect(
+      await findByText(STATE_NAMES_DATASET_METADATA.description)
+    ).toBeInTheDocument();
+  });
+
+  test("opens collapsed preview of dataset fields", async () => {
+    mockGetDatasets.mockReturnValue(
+      Promise.resolve([STATE_NAMES_DATASET_METADATA])
+    );
+
+    const { findByTestId, findByText, queryByText } = render(
+      <DatasetExplorer />
+    );
+    expect(
+      queryByText(STATE_NAMES_DATASET_METADATA.fields[0].description)
+    ).toBeNull();
+    fireEvent.click(
+      await findByTestId("expand-" + STATE_NAMES_DATASET_METADATA.id)
+    );
+
+    expect(mockGetDatasets).toHaveBeenCalledTimes(1);
+    expect(mockLoadDataset).toHaveBeenCalledTimes(0);
+    expect(
+      await findByText(STATE_NAMES_DATASET_METADATA.fields[0].description)
+    ).toBeInTheDocument();
+  });
+
+  test("loads dataset preview", async () => {
+    mockGetDatasets.mockReturnValue(
+      Promise.resolve([STATE_NAMES_DATASET_METADATA])
+    );
+    mockLoadDataset.mockReturnValue(Promise.resolve(STATE_NAMES_DATASET_DATA));
+
+    const { findByTestId, findByText, queryByText } = render(
+      <DatasetExplorer />
+    );
+    fireEvent.click(
+      await findByTestId("preview-" + STATE_NAMES_DATASET_METADATA.id)
+    );
+
+    expect(mockGetDatasets).toHaveBeenCalledTimes(1);
+    expect(mockLoadDataset).toHaveBeenCalledTimes(1);
+    expect(mockLoadDataset).toHaveBeenCalledWith(
+      STATE_NAMES_DATASET_METADATA.id
+    );
+  });
+});

--- a/app/src/features/dataset_explorer/DatasetExplorer.test.tsx
+++ b/app/src/features/dataset_explorer/DatasetExplorer.test.tsx
@@ -9,8 +9,18 @@ const STATE_NAMES_DATASET_METADATA: DatasetMetadata = {
   name: "State Names",
   description: "List of states and their FIPS codes.",
   fields: [
-    { data_type: "string", description: "FIELD_NAME1", data_source_id: "DS1" },
-    { data_type: "string", description: "FIELD_NAME2", data_source_id: "DS1" },
+    {
+      data_type: "string",
+      name: "FIELD_NAME1",
+      description: "description field1",
+      origin_dataset: "DS1",
+    },
+    {
+      data_type: "string",
+      name: "FIELD_NAME2",
+      description: "description field2",
+      origin_dataset: "DS1",
+    },
   ],
 };
 
@@ -23,28 +33,28 @@ const STATE_NAMES_DATASET_DATA = {
 };
 
 describe("DatasetExplorer", () => {
-  const mockGetDatasets = jest.fn();
+  const mockGetMetadata = jest.fn();
   const mockLoadDataset = jest.fn();
 
   beforeEach(() => {
     jest.mock("../../utils/DataFetcher");
-    DataFetcher.prototype.getDatasets = mockGetDatasets;
+    DataFetcher.prototype.getMetadata = mockGetMetadata;
     DataFetcher.prototype.loadDataset = mockLoadDataset;
   });
 
   afterEach(() => {
-    mockGetDatasets.mockClear();
+    mockGetMetadata.mockClear();
     mockLoadDataset.mockClear();
   });
 
   test("renders dataset metadata retrieved from DataFetcher", async () => {
-    mockGetDatasets.mockReturnValue(
-      Promise.resolve([STATE_NAMES_DATASET_METADATA])
+    mockGetMetadata.mockReturnValue(
+      Promise.resolve({ state_names: STATE_NAMES_DATASET_METADATA })
     );
 
     const { findByText } = render(<DatasetExplorer />);
 
-    expect(mockGetDatasets).toHaveBeenCalledTimes(1);
+    expect(mockGetMetadata).toHaveBeenCalledTimes(1);
     expect(mockLoadDataset).toHaveBeenCalledTimes(0);
     expect(
       await findByText(STATE_NAMES_DATASET_METADATA.description)
@@ -52,8 +62,8 @@ describe("DatasetExplorer", () => {
   });
 
   test("opens collapsed preview of dataset fields", async () => {
-    mockGetDatasets.mockReturnValue(
-      Promise.resolve([STATE_NAMES_DATASET_METADATA])
+    mockGetMetadata.mockReturnValue(
+      Promise.resolve({ state_names: STATE_NAMES_DATASET_METADATA })
     );
 
     const { findByTestId, findByText, queryByText } = render(
@@ -66,7 +76,7 @@ describe("DatasetExplorer", () => {
       await findByTestId("expand-" + STATE_NAMES_DATASET_METADATA.id)
     );
 
-    expect(mockGetDatasets).toHaveBeenCalledTimes(1);
+    expect(mockGetMetadata).toHaveBeenCalledTimes(1);
     expect(mockLoadDataset).toHaveBeenCalledTimes(0);
     expect(
       await findByText(STATE_NAMES_DATASET_METADATA.fields[0].description)
@@ -74,8 +84,8 @@ describe("DatasetExplorer", () => {
   });
 
   test("loads dataset preview", async () => {
-    mockGetDatasets.mockReturnValue(
-      Promise.resolve([STATE_NAMES_DATASET_METADATA])
+    mockGetMetadata.mockReturnValue(
+      Promise.resolve({ state_names: STATE_NAMES_DATASET_METADATA })
     );
     mockLoadDataset.mockReturnValue(Promise.resolve(STATE_NAMES_DATASET_DATA));
 
@@ -84,10 +94,8 @@ describe("DatasetExplorer", () => {
       await findByTestId("preview-" + STATE_NAMES_DATASET_METADATA.id)
     );
 
-    expect(mockGetDatasets).toHaveBeenCalledTimes(1);
+    expect(mockGetMetadata).toHaveBeenCalledTimes(1);
     expect(mockLoadDataset).toHaveBeenCalledTimes(1);
-    expect(mockLoadDataset).toHaveBeenCalledWith(
-      STATE_NAMES_DATASET_METADATA.id
-    );
+    expect(mockLoadDataset).toHaveBeenCalledWith("state_names");
   });
 });

--- a/app/src/features/dataset_explorer/DatasetExplorer.tsx
+++ b/app/src/features/dataset_explorer/DatasetExplorer.tsx
@@ -28,7 +28,7 @@ function DatasetExplorer() {
   const [loadStatus, setLoadStatus] = useState<LoadStatus>("unloaded");
   const [previewedSourceId, setPreviewedSourceId] = useState("");
   const [data, setData] = useState([]);
-  const [datasets, setDatasets] = useState<DatasetMetadata[]>([]);
+  const [datasets, setDatasets] = useState<Record<string, DatasetMetadata>>({});
   const [columns, setColumns] = useState([]);
   const [activeFilter, setActiveFilter] = useState<Array<string>>([]);
 
@@ -36,11 +36,11 @@ function DatasetExplorer() {
   useEffect(() => {
     async function updateDatasets() {
       const fetcher = new DataFetcher();
-      const datasets = await fetcher.getDatasets();
-      setDatasets([...datasets]);
+      const datasets = await fetcher.getMetadata();
+      setDatasets(Object.assign(datasets));
     }
     /* Only need to fetch datasets if they have not yet been fetched */
-    if (datasets.length === 0) {
+    if (Object.keys(datasets).length === 0) {
       updateDatasets();
     }
     // ignore warning about datasets.length dependency
@@ -70,20 +70,20 @@ function DatasetExplorer() {
             onSelectionChange={filterSources}
           />
         </div>
-        {datasets
+        {Object.keys(datasets)
           .filter(
-            (dataset) =>
-              activeFilter.length === 0 || activeFilter.includes(dataset.id)
+            (dataset_id) =>
+              activeFilter.length === 0 || activeFilter.includes(dataset_id)
           )
-          .map((dataset, index) => (
+          .map((dataset_id, index) => (
             <div className={styles.Dataset} key={index}>
               <div className={styles.DatasetListItem}>
                 <DatasetListing
-                  dataset={dataset}
-                  onPreview={() => loadPreview(dataset.id)}
+                  dataset={datasets[dataset_id]}
+                  onPreview={() => loadPreview(dataset_id)}
                 />
               </div>
-              {previewedSourceId === dataset.id ? <ChevronRightIcon /> : null}
+              {previewedSourceId === dataset_id ? <ChevronRightIcon /> : null}
             </div>
           ))}
       </div>

--- a/app/src/features/dataset_explorer/DatasetFilter.tsx
+++ b/app/src/features/dataset_explorer/DatasetFilter.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Select, { ActionTypes } from "react-select";
+import { DatasetMetadata } from "../../utils/DatasetMetadata";
 
 const changeActions: Array<ActionTypes> = [
   "select-option",
@@ -8,12 +9,12 @@ const changeActions: Array<ActionTypes> = [
 ];
 
 function DatasetFilter(props: {
-  sources: Array<{ id: string; displayName: string; description: string }>;
+  datasets: Array<DatasetMetadata>;
   onSelectionChange: (filtered: Array<string>) => void;
 }) {
-  const options = props.sources
+  const options = props.datasets
     .slice()
-    .map((source) => ({ value: source.id, label: source.displayName }));
+    .map((dataset) => ({ value: dataset.id, label: dataset.name }));
   return (
     <Select
       options={options}

--- a/app/src/features/dataset_explorer/DatasetFilter.tsx
+++ b/app/src/features/dataset_explorer/DatasetFilter.tsx
@@ -9,12 +9,15 @@ const changeActions: Array<ActionTypes> = [
 ];
 
 function DatasetFilter(props: {
-  datasets: Array<DatasetMetadata>;
+  datasets: Record<string, DatasetMetadata>;
   onSelectionChange: (filtered: Array<string>) => void;
 }) {
-  const options = props.datasets
+  const options = Object.keys(props.datasets)
     .slice()
-    .map((dataset) => ({ value: dataset.id, label: dataset.name }));
+    .map((dataset_id) => ({
+      value: dataset_id,
+      label: props.datasets[dataset_id].name,
+    }));
   return (
     <Select
       options={options}

--- a/app/src/features/dataset_explorer/DatasetListing.tsx
+++ b/app/src/features/dataset_explorer/DatasetListing.tsx
@@ -18,6 +18,7 @@ function FieldsTable(props: { fields: Array<Field> }) {
     <Table size="small" aria-label="dataset field descriptions">
       <TableHead>
         <TableRow>
+          <TableCell>Name</TableCell>
           <TableCell>Description</TableCell>
           <TableCell>Data Type</TableCell>
           <TableCell>Data Source ID</TableCell>
@@ -26,9 +27,10 @@ function FieldsTable(props: { fields: Array<Field> }) {
       <TableBody>
         {props.fields.map((field, index) => (
           <TableRow key={index}>
+            <TableCell>{field.name}</TableCell>
             <TableCell>{field.description}</TableCell>
             <TableCell>{field.data_type}</TableCell>
-            <TableCell>{field.data_source_id}</TableCell>
+            <TableCell>{field.origin_dataset}</TableCell>
           </TableRow>
         ))}
       </TableBody>

--- a/app/src/features/dataset_explorer/DatasetListing.tsx
+++ b/app/src/features/dataset_explorer/DatasetListing.tsx
@@ -47,6 +47,7 @@ function DatasetListing(props: {
         <IconButton
           aria-label="expand dataset"
           onClick={() => setExpanded(!expanded)}
+          data-testid={"expand-" + props.dataset.id}
           className={styles.ExpandButton}
         >
           {expanded ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
@@ -61,6 +62,7 @@ function DatasetListing(props: {
                 setExpanded(true);
                 props.onPreview();
               }}
+              data-testid={"preview-" + props.dataset.id}
               className={styles.PreviewButton}
             >
               Preview
@@ -70,7 +72,7 @@ function DatasetListing(props: {
         </div>
       </div>
       <Collapse in={expanded} timeout="auto" className={styles.MoreInfo}>
-        <FieldsTable fields={props.dataset.fields} />
+        <FieldsTable fields={props.dataset.fields} key={props.dataset.id} />
       </Collapse>
     </Paper>
   );

--- a/app/src/features/dataset_explorer/DatasetListing.tsx
+++ b/app/src/features/dataset_explorer/DatasetListing.tsx
@@ -1,14 +1,43 @@
 import React, { useState } from "react";
-import Button from "@material-ui/core/Button";
+import { DatasetMetadata, Field } from "../../utils/DatasetMetadata";
 import styles from "./DatasetListing.module.scss";
+import Button from "@material-ui/core/Button";
 import Paper from "@material-ui/core/Paper";
 import Collapse from "@material-ui/core/Collapse";
 import IconButton from "@material-ui/core/IconButton";
 import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableHead from "@material-ui/core/TableHead";
+import TableRow from "@material-ui/core/TableRow";
+
+function FieldsTable(props: { fields: Array<Field> }) {
+  return (
+    <Table size="small" aria-label="dataset field descriptions">
+      <TableHead>
+        <TableRow>
+          <TableCell>Description</TableCell>
+          <TableCell>Data Type</TableCell>
+          <TableCell>Data Source ID</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {props.fields.map((field, index) => (
+          <TableRow key={index}>
+            <TableCell>{field.description}</TableCell>
+            <TableCell>{field.data_type}</TableCell>
+            <TableCell>{field.data_source_id}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
 
 function DatasetListing(props: {
-  source: { id: string; displayName: string; description: string };
+  dataset: DatasetMetadata;
   onPreview: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -24,9 +53,7 @@ function DatasetListing(props: {
         </IconButton>
         <div className={styles.FlexCol}>
           <div className={styles.FlexRow}>
-            <div className={styles.DatasetTitle}>
-              {props.source.displayName}
-            </div>
+            <div className={styles.DatasetTitle}>{props.dataset.name}</div>
             <Button
               variant="contained"
               color="primary"
@@ -39,13 +66,11 @@ function DatasetListing(props: {
               Preview
             </Button>
           </div>
-          <div>{props.source.description}</div>
+          <div>{props.dataset.description}</div>
         </div>
       </div>
       <Collapse in={expanded} timeout="auto" className={styles.MoreInfo}>
-        <p>
-          More details... this should probably contain schema, publisher, etc.
-        </p>
+        <FieldsTable fields={props.dataset.fields} />
       </Collapse>
     </Paper>
   );

--- a/app/src/utils/DataFetcher.ts
+++ b/app/src/utils/DataFetcher.ts
@@ -2,6 +2,8 @@
 // untyped for now, but we should define types for the API calls once we
 // establish the API types.
 
+import { DatasetMetadata } from "./DatasetMetadata";
+
 class DataFetcher {
   private async loadData(url: string) {
     const r = await fetch(url);
@@ -45,6 +47,65 @@ class DataFetcher {
     const url = this.getUrl(datasetId);
     const data = await this.loadData(url);
     return this.convertJson(data);
+  }
+
+  async getDatasets() {
+    /* TODO: populate this with real API call */
+    let state_names: DatasetMetadata = {
+      id: "state_names",
+      name: "State Names",
+      description: "List of states and their FIPS codes.",
+      fields: [
+        { data_type: "string", description: "NAME", data_source_id: "DS1" },
+        { data_type: "string", description: "state", data_source_id: "DS1" },
+      ],
+    };
+    let county_names: DatasetMetadata = {
+      id: "county_names",
+      name: "County Names",
+      description: "List of counties and their FIPS codes.",
+      fields: [
+        { data_type: "string", description: "NAME", data_source_id: "DS1" },
+        { data_type: "string", description: "state", data_source_id: "DS1" },
+        { data_type: "string", description: "county", data_source_id: "DS1" },
+      ],
+    };
+    let pop_by_race: DatasetMetadata = {
+      id: "pop_by_race",
+      name: "County Population by Race",
+      description: "The population of each county broken down by race.",
+      fields: [
+        { data_type: "string", description: "NAME", data_source_id: "DS2" },
+        {
+          data_type: "integer",
+          description: "DP05_0070E",
+          data_source_id: "DS2",
+        },
+        {
+          data_type: "integer",
+          description: "DP05_0071E",
+          data_source_id: "DS2",
+        },
+        {
+          data_type: "integer",
+          description: "DP05_0077E",
+          data_source_id: "DS2",
+        },
+        {
+          data_type: "integer",
+          description: "DP05_0078E",
+          data_source_id: "DS2",
+        },
+        {
+          data_type: "integer",
+          description: "DP05_0080E",
+          data_source_id: "DS2",
+        },
+        { data_type: "string", description: "state", data_source_id: "DS2" },
+        { data_type: "string", description: "county", data_source_id: "DS2" },
+      ],
+    };
+    return [state_names, county_names, pop_by_race];
   }
 }
 

--- a/app/src/utils/DataFetcher.ts
+++ b/app/src/utils/DataFetcher.ts
@@ -49,15 +49,25 @@ class DataFetcher {
     return this.convertJson(data);
   }
 
-  async getDatasets() {
+  async getMetadata(): Promise<Record<string, DatasetMetadata>> {
     /* TODO: populate this with real API call */
     let state_names: DatasetMetadata = {
       id: "state_names",
       name: "State Names",
       description: "List of states and their FIPS codes.",
       fields: [
-        { data_type: "string", description: "NAME", data_source_id: "DS1" },
-        { data_type: "string", description: "state", data_source_id: "DS1" },
+        {
+          data_type: "string",
+          name: "NAME",
+          description: "Name of the state",
+          origin_dataset: "DS1",
+        },
+        {
+          data_type: "string",
+          name: "state",
+          description: "State FIPS code",
+          origin_dataset: "DS1",
+        },
       ],
     };
     let county_names: DatasetMetadata = {
@@ -65,9 +75,24 @@ class DataFetcher {
       name: "County Names",
       description: "List of counties and their FIPS codes.",
       fields: [
-        { data_type: "string", description: "NAME", data_source_id: "DS1" },
-        { data_type: "string", description: "state", data_source_id: "DS1" },
-        { data_type: "string", description: "county", data_source_id: "DS1" },
+        {
+          data_type: "string",
+          name: "NAME",
+          description: "Name of the state",
+          origin_dataset: "DS1",
+        },
+        {
+          data_type: "string",
+          name: "state",
+          description: "State FIPS code",
+          origin_dataset: "DS1",
+        },
+        {
+          data_type: "string",
+          name: "county",
+          description: "FIPS code of the county",
+          origin_dataset: "DS1",
+        },
       ],
     };
     let pop_by_race: DatasetMetadata = {
@@ -75,37 +100,62 @@ class DataFetcher {
       name: "County Population by Race",
       description: "The population of each county broken down by race.",
       fields: [
-        { data_type: "string", description: "NAME", data_source_id: "DS2" },
         {
-          data_type: "integer",
-          description: "DP05_0070E",
-          data_source_id: "DS2",
+          data_type: "string",
+          name: "NAME",
+          description: "name of the county",
+          origin_dataset: "DS1",
         },
         {
           data_type: "integer",
-          description: "DP05_0071E",
-          data_source_id: "DS2",
+          name: "DP05_0070E",
+          description: "???",
+          origin_dataset: "DS2",
         },
         {
           data_type: "integer",
-          description: "DP05_0077E",
-          data_source_id: "DS2",
+          name: "DP05_0071E",
+          description: "???",
+          origin_dataset: "DS2",
         },
         {
           data_type: "integer",
-          description: "DP05_0078E",
-          data_source_id: "DS2",
+          name: "DP05_0077E",
+          description: "???",
+          origin_dataset: "DS2",
         },
         {
           data_type: "integer",
-          description: "DP05_0080E",
-          data_source_id: "DS2",
+          name: "DP05_0078E",
+          description: "???",
+          origin_dataset: "DS2",
         },
-        { data_type: "string", description: "state", data_source_id: "DS2" },
-        { data_type: "string", description: "county", data_source_id: "DS2" },
+        {
+          data_type: "integer",
+          name: "DP05_0080E",
+          description: "???",
+          origin_dataset: "DS2",
+        },
+        {
+          data_type: "string",
+          name: "state",
+          description: "State FIPS code",
+          origin_dataset: "DS1",
+        },
+        {
+          data_type: "string",
+          name: "county",
+          description: "FIPS code of the county",
+          origin_dataset: "DS1",
+        },
       ],
     };
-    return [state_names, county_names, pop_by_race];
+
+    return {
+      state_names: state_names,
+      county_names: county_names,
+      pop_by_race: pop_by_race,
+    };
   }
 }
 

--- a/app/src/utils/DatasetMetadata.ts
+++ b/app/src/utils/DatasetMetadata.ts
@@ -4,11 +4,12 @@ export interface DatasetMetadata {
   id: string;
   name: string;
   description: string;
-  fields: Array<Field>;
+  fields: Field[];
 }
 
 export interface Field {
   data_type: string;
+  name: string;
   description: string;
-  data_source_id: string;
+  origin_dataset: string;
 }

--- a/app/src/utils/DatasetMetadata.ts
+++ b/app/src/utils/DatasetMetadata.ts
@@ -1,0 +1,14 @@
+/* TODO: These are not yet comprehensive, final interfaces */
+
+export interface DatasetMetadata {
+  id: string;
+  name: string;
+  description: string;
+  fields: Array<Field>;
+}
+
+export interface Field {
+  data_type: string;
+  description: string;
+  data_source_id: string;
+}


### PR DESCRIPTION
I have written some minor unit tests but I'm not sure to what extent we really want them. I thought it may at least be nice to have some examples to go off in the future. I think they can be useful to verify you're not making extra API calls or re-rendering things more than expected which can be difficult to test visually.

If it ends up being burdensome to keep them up to date, we can always remove them.